### PR TITLE
store blackduck run artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,13 +78,9 @@ commands:
 #            --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
 #            --detect.docker.image=digitalasset/daml-on-fabric:2.0.0 \
 #            --detect.docker.image=digitalasset/daml-on-fabric-chaincode:2.0.0 \
-      - run:
-          command: |
-            NOTICES_FILENAME="$(echo "${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME}_${CIRCLE_BRANCH}" | sed -r 's/-/_/g' | awk '{print tolower($0)}')_Black_Duck_Notices_Report.txt"
-            cp $NOTICES_FILENAME NOTICES
       - store_artifacts:
-          name: Store the NOTICES.txt file
-          path: NOTICES.txt
+          name: Store the Blackduck run artifacts
+          path: /home/circleci/blackduck/runs
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ workflows:
       - build
 
   blackduck:
-    triggers:
-      - schedule:
-          cron: "30 8 * * 1-5"
-          filters:
-             branches:
-                only:
-                  - master
+#     triggers:
+#       - schedule:
+#           cron: "30 8 * * 1-5"
+#           filters:
+#              branches:
+#                 only:
+#                   - master
     jobs:
       - blackduck-build:
           context: blackduck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
             ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
-            --detect.notices.report=true \
+            --detect.notices.report=false \
             --detect.excluded.detector.types=GO_MOD \
             --detect.report.timeout=1100
 # TODO cannot enable until upgraded to DAML 1.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,13 +119,13 @@ workflows:
       - build
 
   blackduck:
-#     triggers:
-#       - schedule:
-#           cron: "30 8 * * 1-5"
-#           filters:
-#              branches:
-#                 only:
-#                   - master
+    triggers:
+      - schedule:
+          cron: "30 8 * * 1-5"
+          filters:
+             branches:
+                only:
+                  - master
     jobs:
       - blackduck-build:
           context: blackduck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ commands:
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
             ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
             --logging.level.com.synopsys.integration=DEBUG \
+            --detect.tools=DETECTOR,BINARY_SCAN \
             --detect.notices.report=false \
             --detect.excluded.detector.types=GO_MOD \
             --detect.cleanup=false \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,8 @@ commands:
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.notices.report=false \
             --detect.excluded.detector.types=GO_MOD \
+            --detect.cleanup=false \
+            --detect.cleanup.bdio.files=false \
             --detect.report.timeout=1100
 # TODO cannot enable until upgraded to DAML 1.3.0
 #            --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \


### PR DESCRIPTION
• store blackduck run artifacts on circleci for diagnostics
• disable signature scan until outstanding blackduck bug is resolved