### PR TITLE
Upgrade to Fabric 2.2.0 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can get the latest Hyperledger Fabric Tools by running the following command
 
 ```
 cd <download_directory>
-curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh | bash -s -- 2.1.0 -s
+curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh | bash -s -- 2.2.0 -s
 ```
 
 Now add the <download_directory>/bin to your PATH so that the fabric tools are available for use
@@ -33,7 +33,7 @@ Now add the <download_directory>/bin to your PATH so that the fabric tools are a
 export PATH=<download_directory>/bin:$PATH
 ```
 
-Full instructions on Fabric Tools can be found at https://hyperledger-fabric.readthedocs.io/en/release-2.0/install.html
+Full instructions on Fabric Tools can be found at https://hyperledger-fabric.readthedocs.io/en/release-2.2/install.html
 
 ## Cloning DAML-on-Fabric
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val akkaVersion = "2.6.10"
 lazy val logbackVersion = "1.2.3"
 lazy val jacksonDataFormatYamlVersion = "2.12.0"
 lazy val protobufVersion = "3.7.1"
-lazy val fabricSdkVersion = "2.1.0"
+lazy val fabricSdkVersion = "2.2.0"
 
 // This task is used by the integration test to detect which version of Ledger API Test Tool to use.
 val printSdkVersion = taskKey[Unit]("printSdkVersion")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 ThisBuild / scalaVersion := "2.12.11"
-ThisBuild / version := "2.0.0"
+ThisBuild / version := "2.2.0"
 ThisBuild / organization := "com.daml"
 ThisBuild / organizationName := "Digital Asset. LLC"
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,13 +25,16 @@ assemblyMergeStrategy in assembly := {
   case "META-INF/io.netty.versions.properties" =>
     MergeStrategy.first
   // clashing bouncycastle metainfo
-  case "META-INF/versions/9/module-info.class" => MergeStrategy.first
+  case "META-INF/versions/9/module-info.class" => 
+    MergeStrategy.first
   // Both in protobuf and akka
   case PathList("google", "protobuf", n) if n.endsWith(".proto") =>
     MergeStrategy.first
   // In all 2.10 Jackson JARs
   case "module-info.class" =>
     MergeStrategy.discard
+  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => 
+    MergeStrategy.rename
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/chaincode-image/Dockerfile
+++ b/chaincode-image/Dockerfile
@@ -1,4 +1,4 @@
-#docker build . -t digitalasset/daml-on-fabric-chaincode:2.0.0
+#docker build . -t digitalasset/daml-on-fabric-chaincode:2.2.0
 
 FROM golang:1.13.5-alpine AS build_base
 

--- a/src/test/fixture/build_ci.sh
+++ b/src/test/fixture/build_ci.sh
@@ -18,4 +18,4 @@ cp ./get_jwks_token.sh tmp
 cp ./damlOnFabricStart.sh tmp
 cp ./Dockerfile tmp
 cd tmp
-docker build . -t digitalasset/daml-on-fabric:2.0.0 --build-arg SDK_VERSION=${SDK_VERSION}
+docker build . -t digitalasset/daml-on-fabric:2.2.0 --build-arg SDK_VERSION=${SDK_VERSION}

--- a/src/test/fixture/docker-compose-ci.yaml
+++ b/src/test/fixture/docker-compose-ci.yaml
@@ -195,7 +195,7 @@ services:
       command: /usr/local/bin/configtxlator start
 
   daml-on-fabric-1:
-      image: digitalasset/daml-on-fabric:2.0.0
+      image: digitalasset/daml-on-fabric:2.2.0
       environment:
         - LEDGER_PORT=11111
         - LEDGER_ROLES=provision,time,ledger
@@ -209,7 +209,7 @@ services:
         - peer0.org2.example.com
 
   daml-on-fabric-2:
-      image: digitalasset/daml-on-fabric:2.0.0
+      image: digitalasset/daml-on-fabric:2.2.0
       environment:
         - LEDGER_PORT=12222
         - LEDGER_ROLES=ledger

--- a/src/test/fixture/fabric.sh
+++ b/src/test/fixture/fabric.sh
@@ -19,9 +19,9 @@ if [[ "${DOCKER_NETWORK}" == "" ]]; then
   DOCKER_NETWORK="damlonfabric"
 fi
 
-export ORG_HYPERLEDGER_FABRIC_SDKTEST_VERSION="2.0.0"
-export IMAGE_TAG_FABRIC_CA=":2.0"
-export IMAGE_TAG_FABRIC=":2.0"
+export ORG_HYPERLEDGER_FABRIC_SDKTEST_VERSION="2.2.0"
+export IMAGE_TAG_FABRIC_CA=":2.2"
+export IMAGE_TAG_FABRIC=":2.2"
 
 function clean(){
 


### PR DESCRIPTION
This PR updates daml-on-fabric to use Fabric 2.2.0. All tests passing (see below) and also tested with create-daml-app.

```
$ java -jar ledger-api-test-tool.jar --all-tests localhost:6865 --timeout-scale-factor=10
WARNING: --all-tests has been deprecated and will be removed in a future version
2021-01-04T17:34:24.631Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[main] - Connecting to participant at localhost:6865...
2021-01-04T17:34:24.634Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[main] - gRPC thread factory instantiated with pool 'grpc-event-loop-localhost-6865' (daemon threads: false)
2021-01-04T17:34:24.720Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[main] - gRPC event loop thread group instantiated with 8 threads using pool 'grpc-event-loop-localhost-6865'
2021-01-04T17:34:25.398Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[kka.actor.default-dispatcher-5] - Connected to participant at localhost:6865.
2021-01-04T17:34:25.430Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploading DAR "/ledger/test-common/model-tests.dar"...
2021-01-04T17:34:25.439Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploading DAR "/ledger/test-common/performance-tests.dar"...
2021-01-04T17:34:25.442Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploading DAR "/ledger/test-common/semantic-tests.dar"...
2021-01-04T17:34:26.189Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploaded DAR "/ledger/test-common/model-tests.dar".
2021-01-04T17:34:26.992Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploaded DAR "/ledger/test-common/performance-tests.dar".
2021-01-04T17:34:27.711Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Uploaded DAR "/ledger/test-common/semantic-tests.dar".
2021-01-04T17:34:27.712Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Running 171 tests, 8 at a time.
2021-01-04T17:34:27.864Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-5] - Started 'The ActiveContractService should fail for requests with an invalid ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:34:27.864Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The ActiveContractService should return all active contracts' with a timeout of 5 minutes.
2021-01-04T17:34:27.864Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The ActiveContractService should succeed with an empty response if no contracts have been created for a party' with a timeout of 5 minutes.
2021-01-04T17:34:27.868Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The ActiveContractService does not return archived contracts' with a timeout of 5 minutes.
2021-01-04T17:34:27.868Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'The ActiveContractService should return contracts filtered by templateId' with a timeout of 5 minutes.
2021-01-04T17:34:27.876Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'The ActiveContractService should return a usable offset to resume streaming transactions' with a timeout of 5 minutes.
2021-01-04T17:34:27.877Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The ActiveContractService should emit field names only if the verbose flag is set to true' with a timeout of 5 minutes.
2021-01-04T17:34:27.877Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The ActiveContractsService should return contracts for the requesting parties' with a timeout of 5 minutes.
2021-01-04T17:34:28.481Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should fail for requests with an invalid ledger identifier'.
2021-01-04T17:34:28.631Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The ActiveContractService should properly fill the agreementText field' with a timeout of 5 minutes.
2021-01-04T17:34:28.685Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should succeed with an empty response if no contracts have been created for a party'.
2021-01-04T17:34:28.691Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The ActiveContractService should properly fill the eventId field' with a timeout of 5 minutes.
2021-01-04T17:34:31.097Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should emit field names only if the verbose flag is set to true'.
2021-01-04T17:34:31.101Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The ActiveContractService should not return witnessed contracts' with a timeout of 5 minutes.
2021-01-04T17:34:31.512Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should properly fill the eventId field'.
2021-01-04T17:34:31.517Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The ActiveContractService should not return divulged contracts' with a timeout of 5 minutes.
2021-01-04T17:34:31.744Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The ActiveContractService should return a usable offset to resume streaming transactions'.
2021-01-04T17:34:31.747Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'Cannot execute a transaction that references unallocated observer parties' with a timeout of 5 minutes.
2021-01-04T17:34:32.642Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should properly fill the agreementText field'.
2021-01-04T17:34:32.646Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'SubmitAndWait creates a contract of the expected template' with a timeout of 5 minutes.
2021-01-04T17:34:33.135Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The ActiveContractService should return all active contracts'.
2021-01-04T17:34:33.139Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransactionId returns a valid transaction identifier' with a timeout of 5 minutes.
2021-01-04T17:34:33.497Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should return contracts filtered by templateId'.
2021-01-04T17:34:33.502Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransaction returns a transaction' with a timeout of 5 minutes.
2021-01-04T17:34:34.796Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'Cannot execute a transaction that references unallocated observer parties'.
2021-01-04T17:34:34.800Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransactionTree returns a transaction tree' with a timeout of 5 minutes.
2021-01-04T17:34:35.065Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService does not return archived contracts'.
2021-01-04T17:34:35.070Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'SubmitAndWait should fail on duplicate requests' with a timeout of 5 minutes.
2021-01-04T17:34:35.533Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The ActiveContractService should not return witnessed contracts'.
2021-01-04T17:34:35.537Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransactionId should fail on duplicate requests' with a timeout of 5 minutes.
2021-01-04T17:34:35.638Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWait creates a contract of the expected template'.
2021-01-04T17:34:35.643Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransaction should fail on duplicate requests' with a timeout of 5 minutes.
2021-01-04T17:34:36.016Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWaitForTransactionId returns a valid transaction identifier'.
2021-01-04T17:34:36.020Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'SubmitAndWaitForTransactionTree should fail on duplicate requests' with a timeout of 5 minutes.
2021-01-04T17:34:36.235Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'SubmitAndWaitForTransaction returns a transaction'.
2021-01-04T17:34:36.239Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'SubmitAndWaitForTransactionId should fail for invalid ledger ids' with a timeout of 5 minutes.
2021-01-04T17:34:37.097Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'The ActiveContractService should not return divulged contracts'.
2021-01-04T17:34:37.101Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'SubmitAndWaitForTransaction should fail for invalid ledger ids' with a timeout of 5 minutes.
2021-01-04T17:34:37.445Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'SubmitAndWaitForTransactionTree returns a transaction tree'.
2021-01-04T17:34:37.452Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'SubmitAndWaitForTransactionTree should fail for invalid ledger ids' with a timeout of 5 minutes.
2021-01-04T17:34:37.686Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'SubmitAndWaitForTransactionId should fail for invalid ledger ids'.
2021-01-04T17:34:37.690Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The submission of a creation that contains a bad parameter label should result in an INVALID_ARGUMENT' with a timeout of 5 minutes.
2021-01-04T17:34:37.802Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWait should fail on duplicate requests'.
2021-01-04T17:34:37.804Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'A submission resulting in an interpretation error should return the stack trace' with a timeout of 5 minutes.
2021-01-04T17:34:37.974Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The ActiveContractsService should return contracts for the requesting parties'.
2021-01-04T17:34:37.978Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'Disclose create to observers' with a timeout of 5 minutes.
2021-01-04T17:34:38.155Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWaitForTransactionId should fail on duplicate requests'.
2021-01-04T17:34:38.160Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Disclose exercise to observers' with a timeout of 5 minutes.
2021-01-04T17:34:38.279Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'SubmitAndWaitForTransaction should fail on duplicate requests'.
2021-01-04T17:34:38.283Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'The server should accept a submission with 15 commands' with a timeout of 5 minutes.
2021-01-04T17:34:38.400Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWaitForTransaction should fail for invalid ledger ids'.
2021-01-04T17:34:38.405Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Run CallablePayout and return the right events' with a timeout of 5 minutes.
2021-01-04T17:34:38.517Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'SubmitAndWaitForTransactionTree should fail on duplicate requests'.
2021-01-04T17:34:38.520Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'It should be possible to exercise a choice on a created contract' with a timeout of 5 minutes.
2021-01-04T17:34:38.638Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'SubmitAndWaitForTransactionTree should fail for invalid ledger ids'.
2021-01-04T17:34:38.642Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Reject unrepresentable numeric values' with a timeout of 5 minutes.
2021-01-04T17:34:38.906Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The submission of a creation that contains a bad parameter label should result in an INVALID_ARGUMENT'.
2021-01-04T17:34:38.909Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'Implement create-and-exercise correctly' with a timeout of 5 minutes.
2021-01-04T17:34:40.836Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'Reject unrepresentable numeric values'.
2021-01-04T17:34:40.841Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'Fail create-and-exercise on bad create arguments' with a timeout of 5 minutes.
2021-01-04T17:34:41.218Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'A submission resulting in an interpretation error should return the stack trace'.
2021-01-04T17:34:41.222Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Fail create-and-exercise on bad choice arguments' with a timeout of 5 minutes.
2021-01-04T17:34:41.764Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The server should accept a submission with 15 commands'.
2021-01-04T17:34:41.767Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Started 'Fail create-and-exercise on invalid choice' with a timeout of 5 minutes.
2021-01-04T17:34:42.253Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'Fail create-and-exercise on bad create arguments'.
2021-01-04T17:34:42.257Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Read completions correctly with a correct application identifier and reading party' with a timeout of 5 minutes.
2021-01-04T17:34:42.488Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-7] - Finished 'Fail create-and-exercise on bad choice arguments'.
2021-01-04T17:34:42.492Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Read no completions without the correct application identifier' with a timeout of 5 minutes.
2021-01-04T17:34:42.516Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Implement create-and-exercise correctly'.
2021-01-04T17:34:42.518Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An OUT_OF_RANGE error should be returned when subscribing to completions past the ledger end' with a timeout of 5 minutes.
2021-01-04T17:34:42.973Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Fail create-and-exercise on invalid choice'.
2021-01-04T17:34:42.976Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Read no completions without the correct party' with a timeout of 5 minutes.
2021-01-04T17:34:43.314Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'It should be possible to exercise a choice on a created contract'.
2021-01-04T17:34:43.317Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT' with a timeout of 5 minutes.
2021-01-04T17:34:43.812Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An OUT_OF_RANGE error should be returned when subscribing to completions past the ledger end'.
2021-01-04T17:34:43.815Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Submit should fail for an invalid ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:34:44.770Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Read completions correctly with a correct application identifier and reading party'.
2021-01-04T17:34:44.773Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'The submission of an empty command should be rejected with INVALID_ARGUMENT' with a timeout of 5 minutes.
2021-01-04T17:34:45.242Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Submit should fail for an invalid ledger identifier'.
2021-01-04T17:34:45.247Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Listening for completions should support multi-party subscriptions' with a timeout of 5 minutes.
2021-01-04T17:34:45.962Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT'.
2021-01-04T17:34:45.964Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Deduplicate commands within the deduplication time window' with a timeout of 5 minutes.
2021-01-04T17:34:46.197Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The submission of an empty command should be rejected with INVALID_ARGUMENT'.
2021-01-04T17:34:46.200Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Stop deduplicating commands on submission failure' with a timeout of 5 minutes.
2021-01-04T17:34:46.783Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Disclose create to observers'.
2021-01-04T17:34:46.785Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Stop deduplicating commands on completion failure' with a timeout of 5 minutes.
2021-01-04T17:34:47.408Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Stop deduplicating commands on submission failure'.
2021-01-04T17:34:47.411Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Deduplicate commands within the deduplication time window using the command client' with a timeout of 5 minutes.
2021-01-04T17:34:47.515Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Listening for completions should support multi-party subscriptions'.
2021-01-04T17:34:47.518Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Commands with identical submitter and command identifier should be deduplicated by the submission client' with a timeout of 5 minutes.
2021-01-04T17:34:48.015Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Disclose exercise to observers'.
2021-01-04T17:34:48.019Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Commands with identical submitter and command identifier should be deduplicated by the command client' with a timeout of 5 minutes.
2021-01-04T17:34:48.143Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Run CallablePayout and return the right events'.
2021-01-04T17:34:48.146Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Divulged contracts cannot be fetched or looked up by key by non-stakeholders' with a timeout of 5 minutes.
2021-01-04T17:34:48.684Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Read no completions without the correct application identifier'.
2021-01-04T17:34:48.687Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Contract Keys should reject fetching an undisclosed contract' with a timeout of 5 minutes.
2021-01-04T17:34:49.287Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Read no completions without the correct party'.
2021-01-04T17:34:49.290Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Contract keys should be scoped by maintainer' with a timeout of 5 minutes.
2021-01-04T17:34:50.041Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Commands with identical submitter and command identifier should be deduplicated by the submission client'.
2021-01-04T17:34:50.043Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Contract keys can be recreated in single transaction' with a timeout of 5 minutes.
2021-01-04T17:34:51.728Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Commands with identical submitter and command identifier should be deduplicated by the command client'.
2021-01-04T17:34:51.731Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Contract keys created by transient contracts are properly archived' with a timeout of 5 minutes.
2021-01-04T17:34:52.551Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Stop deduplicating commands on completion failure'.
2021-01-04T17:34:52.554Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The contract key should be exposed if the template specifies one' with a timeout of 5 minutes.
2021-01-04T17:34:53.396Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Contract keys can be recreated in single transaction'.
2021-01-04T17:34:53.399Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Exercising by key should be possible only when the corresponding contract is available' with a timeout of 5 minutes.
2021-01-04T17:34:54.230Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Deduplicate commands within the deduplication time window'.
2021-01-04T17:34:54.234Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Divulged contracts should not be exposed by the transaction service' with a timeout of 5 minutes.
2021-01-04T17:34:54.623Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'The contract key should be exposed if the template specifies one'.
2021-01-04T17:34:54.627Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Divulged contracts should not be exposed by the active contract service' with a timeout of 5 minutes.
2021-01-04T17:34:55.909Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Deduplicate commands within the deduplication time window using the command client'.
2021-01-04T17:34:55.912Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Divulgence should behave as expected in a workflow involving keys' with a timeout of 5 minutes.
2021-01-04T17:34:56.620Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Divulged contracts cannot be fetched or looked up by key by non-stakeholders'.
2021-01-04T17:34:56.623Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'The Health.Check endpoint reports everything is well' with a timeout of 5 minutes.
2021-01-04T17:34:56.642Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'The Health.Check endpoint reports everything is well'.
2021-01-04T17:34:56.644Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'The Health.Watch endpoint reports everything is well' with a timeout of 5 minutes.
2021-01-04T17:34:57.230Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Exercising by key should be possible only when the corresponding contract is available'.
2021-01-04T17:34:57.232Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'A ledger should return a non-empty string as its identity' with a timeout of 5 minutes.
2021-01-04T17:34:57.237Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'A ledger should return a non-empty string as its identity'.
2021-01-04T17:34:57.240Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Return a valid configuration for a valid request' with a timeout of 5 minutes.
2021-01-04T17:34:57.276Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Return a valid configuration for a valid request'.
2021-01-04T17:34:57.278Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Return NOT_FOUND to invalid ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:34:57.283Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Return NOT_FOUND to invalid ledger identifier'.
2021-01-04T17:34:57.286Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Submission returns OK if deduplication time is within the accepted interval' with a timeout of 5 minutes.
2021-01-04T17:34:57.654Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'The Health.Watch endpoint reports everything is well'.
2021-01-04T17:34:57.657Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Submission returns OK if deduplication time is too high' with a timeout of 5 minutes.
2021-01-04T17:34:57.823Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Contract keys created by transient contracts are properly archived'.
2021-01-04T17:34:57.825Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An attempt at uploading an empty payload should fail' with a timeout of 5 minutes.
2021-01-04T17:34:57.835Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An attempt at uploading an empty payload should fail'.
2021-01-04T17:34:57.838Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Concurrent uploads of the same package should be idempotent and result in the package being available for use' with a timeout of 5 minutes.
2021-01-04T17:34:58.061Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Contract Keys should reject fetching an undisclosed contract'.
2021-01-04T17:34:58.063Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Listing packages should return a result' with a timeout of 5 minutes.
2021-01-04T17:34:58.080Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Listing packages should return a result'.
2021-01-04T17:34:58.082Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Getting package content should return a valid result' with a timeout of 5 minutes.
2021-01-04T17:34:58.106Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Getting package content should return a valid result'.
2021-01-04T17:34:58.109Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Getting package content for an unknown package should fail' with a timeout of 5 minutes.
2021-01-04T17:34:58.115Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Getting package content for an unknown package should fail'.
2021-01-04T17:34:58.118Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Getting package status should return a valid result' with a timeout of 5 minutes.
2021-01-04T17:34:58.142Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Getting package status should return a valid result'.
2021-01-04T17:34:58.144Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Getting package status for an unknown package should fail' with a timeout of 5 minutes.
2021-01-04T17:34:58.151Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Getting package status for an unknown package should fail'.
2021-01-04T17:34:58.154Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'Asking for the participant identifier should return a non-empty string' with a timeout of 5 minutes.
2021-01-04T17:34:58.166Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Asking for the participant identifier should return a non-empty string'.
2021-01-04T17:34:58.168Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should be possible to provide a hint when allocating a party' with a timeout of 5 minutes.
2021-01-04T17:34:58.432Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Submission returns OK if deduplication time is within the accepted interval'.
2021-01-04T17:34:58.435Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'It should be possible to not provide a hint when allocating a party' with a timeout of 5 minutes.
2021-01-04T17:34:58.918Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'Submission returns OK if deduplication time is too high'.
2021-01-04T17:34:58.920Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should be possible to not provide a display name when allocating a party' with a timeout of 5 minutes.
2021-01-04T17:34:59.386Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'It should be possible to provide a hint when allocating a party'.
2021-01-04T17:35:00.355Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should be possible to allocate parties with the same display names' with a timeout of 5 minutes.
2021-01-04T17:35:00.356Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Finished 'It should be possible to not provide a display name when allocating a party'.
2021-01-04T17:35:00.356Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should be possible to not provide a hint when allocating a party'.
2021-01-04T17:35:00.999Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'It should create unique party names when allocating many parties' with a timeout of 5 minutes.
2021-01-04T17:35:00.999Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-6] - Started 'It should get details for multiple parties, if they exist' with a timeout of 5 minutes.
2021-01-04T17:35:01.027Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Divulged contracts should not be exposed by the active contract service'.
2021-01-04T17:35:01.106Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should list all known, previously-allocated parties' with a timeout of 5 minutes.
2021-01-04T17:35:01.128Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Divulged contracts should not be exposed by the transaction service'.
2021-01-04T17:35:01.131Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'GetParties should correctly report whether parties are local or not' with a timeout of 5 minutes.
2021-01-04T17:35:05.984Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Divulgence should behave as expected in a workflow involving keys'.
2021-01-04T17:35:05.986Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Cannot double spend across transactions' with a timeout of 5 minutes.
2021-01-04T17:35:20.382Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should create unique party names when allocating many parties'.
2021-01-04T17:35:20.387Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Cannot concurrently double spend across transactions' with a timeout of 5 minutes.
2021-01-04T17:35:21.933Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should be possible to allocate parties with the same display names'.
2021-01-04T17:35:21.935Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Cannot double spend within a transaction' with a timeout of 5 minutes.
2021-01-04T17:35:22.067Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should get details for multiple parties, if they exist'.
2021-01-04T17:35:22.069Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Different parties cannot spend the same contract' with a timeout of 5 minutes.
2021-01-04T17:35:23.019Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Concurrent uploads of the same package should be idempotent and result in the package being available for use'.
2021-01-04T17:35:23.024Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Conduct the paint offer workflow successfully' with a timeout of 5 minutes.
2021-01-04T17:35:24.212Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should list all known, previously-allocated parties'.
2021-01-04T17:35:24.215Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Conduct the paint counter-offer workflow successfully' with a timeout of 5 minutes.
2021-01-04T17:35:24.457Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'GetParties should correctly report whether parties are local or not'.
2021-01-04T17:35:24.459Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'A signatory should not be able to create a contract on behalf of two parties' with a timeout of 5 minutes.
2021-01-04T17:35:25.056Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Cannot double spend across transactions'.
2021-01-04T17:35:25.058Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should not be possible to exercise a choice without the consent of the controller' with a timeout of 5 minutes.
2021-01-04T17:35:25.185Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Cannot double spend within a transaction'.
2021-01-04T17:35:25.187Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Test visibility via contract fetches for the paint-offer flow' with a timeout of 10 minutes.
2021-01-04T17:35:26.174Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'A signatory should not be able to create a contract on behalf of two parties'.
2021-01-04T17:35:26.177Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Respect divulgence rules' with a timeout of 5 minutes.
2021-01-04T17:35:30.630Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Conduct the paint offer workflow successfully'.
2021-01-04T17:35:30.633Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An empty stream should be served when getting transactions from and to the beginning of the ledger' with a timeout of 5 minutes.
2021-01-04T17:35:30.700Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should not be possible to exercise a choice without the consent of the controller'.
2021-01-04T17:35:30.701Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An empty stream of trees should be served when getting transactions from and to the beginning of the ledger' with a timeout of 5 minutes.
2021-01-04T17:35:31.674Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Contract keys should be scoped by maintainer'.
2021-01-04T17:35:31.676Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An empty stream should be served when getting transactions from and to the end of the ledger' with a timeout of 5 minutes.
2021-01-04T17:35:31.778Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An empty stream should be served when getting transactions from and to the beginning of the ledger'.
2021-01-04T17:35:31.781Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'An OUT_OF_RANGE error should be returned when subscribing past the ledger end' with a timeout of 5 minutes.
2021-01-04T17:35:31.898Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An empty stream of trees should be served when getting transactions from and to the beginning of the ledger'.
2021-01-04T17:35:31.900Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'An OUT_OF_RANGE error should be returned when subscribing to trees past the ledger end' with a timeout of 5 minutes.
2021-01-04T17:35:33.497Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Conduct the paint counter-offer workflow successfully'.
2021-01-04T17:35:33.499Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Items should be served until the client cancels' with a timeout of 5 minutes.
2021-01-04T17:35:34.302Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Different parties cannot spend the same contract'.
2021-01-04T17:35:34.304Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Trees should be served until the client cancels' with a timeout of 5 minutes.
2021-01-04T17:35:34.900Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An empty stream should be served when getting transactions from and to the end of the ledger'.
2021-01-04T17:35:34.903Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Trees should be served according to the blinding/projection rules' with a timeout of 5 minutes.
2021-01-04T17:35:35.048Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'An OUT_OF_RANGE error should be returned when subscribing past the ledger end'.
2021-01-04T17:35:35.051Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status' with a timeout of 5 minutes.
2021-01-04T17:35:35.256Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'An OUT_OF_RANGE error should be returned when subscribing to trees past the ledger end'.
2021-01-04T17:35:35.258Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'A stream should complete as soon as the ledger end is hit' with a timeout of 5 minutes.
2021-01-04T17:35:38.142Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Items should be served until the client cancels'.
2021-01-04T17:35:38.144Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'A stream of trees should complete as soon as the ledger end is hit' with a timeout of 5 minutes.
2021-01-04T17:35:38.868Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status'.
2021-01-04T17:35:38.875Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'Serve the complete sequence of transactions even if processing is stopped and resumed' with a timeout of 5 minutes.
2021-01-04T17:35:41.627Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'Trees should be served until the client cancels'.
2021-01-04T17:35:41.632Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The same data should be served for more than 1 identical, parallel requests' with a timeout of 5 minutes.
2021-01-04T17:35:44.720Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'A stream should complete as soon as the ledger end is hit'.
2021-01-04T17:35:44.722Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Data should not be exposed to parties unrelated to a transaction' with a timeout of 5 minutes.
2021-01-04T17:35:46.882Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'A stream of trees should complete as soon as the ledger end is hit'.
2021-01-04T17:35:46.886Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'A request with the end before the begin should be rejected with INVALID_ARGUMENT' with a timeout of 5 minutes.
2021-01-04T17:35:49.177Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The same data should be served for more than 1 identical, parallel requests'.
2021-01-04T17:35:49.179Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'A transaction should be visible to a non-submitting stakeholder but its command identifier should be empty' with a timeout of 5 minutes.
2021-01-04T17:35:50.381Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Serve the complete sequence of transactions even if processing is stopped and resumed'.
2021-01-04T17:35:50.382Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The transaction service should correctly filter by template identifier' with a timeout of 5 minutes.
2021-01-04T17:35:50.487Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Data should not be exposed to parties unrelated to a transaction'.
2021-01-04T17:35:50.489Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Should be able to directly use a contract identifier to exercise a choice' with a timeout of 5 minutes.
2021-01-04T17:35:52.041Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Cannot concurrently double spend across transactions'.
2021-01-04T17:35:52.043Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose contract identifiers that are results of exercising choices when filtering by template' with a timeout of 5 minutes.
2021-01-04T17:35:52.164Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'A request with the end before the begin should be rejected with INVALID_ARGUMENT'.
2021-01-04T17:35:52.165Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Reject a transaction on a failing assertion' with a timeout of 5 minutes.
2021-01-04T17:35:53.005Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'A transaction should be visible to a non-submitting stakeholder but its command identifier should be empty'.
2021-01-04T17:35:53.007Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Creates should not have issues dealing with any type of argument' with a timeout of 5 minutes.
2021-01-04T17:35:53.490Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The transaction service should correctly filter by template identifier'.
2021-01-04T17:35:53.492Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Exercise should not have issues dealing with any type of argument' with a timeout of 5 minutes.
2021-01-04T17:35:54.207Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Reject a transaction on a failing assertion'.
2021-01-04T17:35:54.209Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Accept a submission with a very long list (10,000 items)' with a timeout of 5 minutes.
2021-01-04T17:35:54.321Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Respect divulgence rules'.
2021-01-04T17:35:54.323Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Expressing a non-consuming choice on a contract should not result in its archival' with a timeout of 5 minutes.
2021-01-04T17:35:54.683Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Should be able to directly use a contract identifier to exercise a choice'.
2021-01-04T17:35:54.684Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Require only authorization of chosen branching signatory' with a timeout of 5 minutes.
2021-01-04T17:35:54.994Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Creates should not have issues dealing with any type of argument'.
2021-01-04T17:35:54.997Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Not disclose create to non-chosen branching signatory' with a timeout of 5 minutes.
2021-01-04T17:35:55.062Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose contract identifiers that are results of exercising choices when filtering by template'.
2021-01-04T17:35:55.065Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Disclose create to the chosen branching controller' with a timeout of 5 minutes.
2021-01-04T17:35:57.612Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Exercise should not have issues dealing with any type of argument'.
2021-01-04T17:35:57.614Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Not disclose create to non-chosen branching controller' with a timeout of 5 minutes.
2021-01-04T17:35:57.796Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Require only authorization of chosen branching signatory'.
2021-01-04T17:35:57.798Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Disclose create to observers' with a timeout of 5 minutes.
2021-01-04T17:35:57.902Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Accept a submission with a very long list (10,000 items)'.
2021-01-04T17:35:57.905Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'DAML engine returns Unit as argument to Nothing' with a timeout of 5 minutes.
2021-01-04T17:35:58.356Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Disclose create to the chosen branching controller'.
2021-01-04T17:35:58.358Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Expose the agreement text for templates with an explicit agreement text' with a timeout of 5 minutes.
2021-01-04T17:35:58.534Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Trees should be served according to the blinding/projection rules'.
2021-01-04T17:35:58.537Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Expose the default text for templates without an agreement text' with a timeout of 5 minutes.
2021-01-04T17:36:00.558Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Disclose create to observers'.
2021-01-04T17:36:00.560Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Expose the correct stakeholders' with a timeout of 5 minutes.
2021-01-04T17:36:00.828Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'DAML engine returns Unit as argument to Nothing'.
2021-01-04T17:36:00.831Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'There should be no contract key if the template does not specify one' with a timeout of 5 minutes.
2021-01-04T17:36:01.280Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose the agreement text for templates with an explicit agreement text'.
2021-01-04T17:36:01.283Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Accept exercising a well-authorized multi-actor choice' with a timeout of 5 minutes.
2021-01-04T17:36:01.637Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose the default text for templates without an agreement text'.
2021-01-04T17:36:01.639Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Accept exercising a well-authorized multi-actor choice with coinciding controllers' with a timeout of 5 minutes.
2021-01-04T17:36:03.916Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Expose the correct stakeholders'.
2021-01-04T17:36:03.917Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Reject exercising a multi-actor choice with missing authorizers' with a timeout of 5 minutes.
2021-01-04T17:36:04.157Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'There should be no contract key if the template does not specify one'.
2021-01-04T17:36:04.158Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Reject exercising a multi-actor choice with too many authorizers' with a timeout of 5 minutes.
2021-01-04T17:36:04.518Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Not disclose create to non-chosen branching signatory'.
2021-01-04T17:36:04.521Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Don't reorder fields in data structures of choices' with a timeout of 5 minutes.
2021-01-04T17:36:04.884Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Expressing a non-consuming choice on a contract should not result in its archival'.
2021-01-04T17:36:04.886Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The same transaction should be served regardless of subscribing as one or multiple parties' with a timeout of 5 minutes.
2021-01-04T17:36:06.916Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Not disclose create to non-chosen branching controller'.
2021-01-04T17:36:06.918Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The same transaction trees should be served regardless of subscribing as one or multiple parties' with a timeout of 5 minutes.
2021-01-04T17:36:07.325Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Reject exercising a multi-actor choice with missing authorizers'.
2021-01-04T17:36:07.326Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The same transaction should be served to all stakeholders' with a timeout of 5 minutes.
2021-01-04T17:36:08.944Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Don't reorder fields in data structures of choices'.
2021-01-04T17:36:08.946Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The same transaction trees should be served to all stakeholders' with a timeout of 5 minutes.
2021-01-04T17:36:09.084Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Accept exercising a well-authorized multi-actor choice'.
2021-01-04T17:36:09.086Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'It should be possible to fetch a contract created within a transaction' with a timeout of 5 minutes.
2021-01-04T17:36:09.259Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The same transaction should be served regardless of subscribing as one or multiple parties'.
2021-01-04T17:36:09.261Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getTransactions endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:09.447Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Accept exercising a well-authorized multi-actor choice with coinciding controllers'.
2021-01-04T17:36:09.449Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getTransactionTrees endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:09.788Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Reject exercising a multi-actor choice with too many authorizers'.
2021-01-04T17:36:09.790Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getTransactionTreeById endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:10.390Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The getTransactions endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:10.392Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getFlatTransactionById endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:10.508Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The getTransactionTrees endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:10.510Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getTransactionTreeByEventId endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:10.833Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The same transaction trees should be served regardless of subscribing as one or multiple parties'.
2021-01-04T17:36:10.835Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The getFlatTransactionByEventId endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:10.987Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The getTransactionTreeById endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:10.989Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The ledgerEnd endpoint should reject calls with the wrong ledger identifier' with a timeout of 5 minutes.
2021-01-04T17:36:10.994Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The ledgerEnd endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:10.996Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose a visible transaction tree by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:11.587Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The getFlatTransactionById endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:11.589Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Do not expose an invisible transaction tree by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:11.705Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The getTransactionTreeByEventId endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:11.707Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return NOT_FOUND when looking up an inexistent transaction tree by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:11.827Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The getFlatTransactionByEventId endpoint should reject calls with the wrong ledger identifier'.
2021-01-04T17:36:11.828Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return INVALID_ARGUMENT when looking up a transaction tree by identifier without specifying a party' with a timeout of 5 minutes.
2021-01-04T17:36:11.833Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Return INVALID_ARGUMENT when looking up a transaction tree by identifier without specifying a party'.
2021-01-04T17:36:11.835Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose the same events for each transaction as the output of getTransactionTrees' with a timeout of 5 minutes.
2021-01-04T17:36:12.661Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'It should be possible to fetch a contract created within a transaction'.
2021-01-04T17:36:12.662Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose a visible transaction by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:13.026Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Return NOT_FOUND when looking up an inexistent transaction tree by identifier'.
2021-01-04T17:36:13.028Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Do not expose an invisible flat transaction by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:14.880Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Expose a visible transaction tree by identifier'.
2021-01-04T17:36:14.881Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return NOT_FOUND when looking up an inexistent flat transaction by identifier' with a timeout of 5 minutes.
2021-01-04T17:36:15.843Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The same transaction should be served to all stakeholders'.
2021-01-04T17:36:15.844Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return INVALID_ARGUMENT when looking up a flat transaction by identifier without specifying a party' with a timeout of 5 minutes.
2021-01-04T17:36:15.848Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Return INVALID_ARGUMENT when looking up a flat transaction by identifier without specifying a party'.
2021-01-04T17:36:15.850Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose the same events for each transaction as the output of getTransactions' with a timeout of 5 minutes.
2021-01-04T17:36:15.906Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Return NOT_FOUND when looking up an inexistent flat transaction by identifier'.
2021-01-04T17:36:15.908Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Expose a visible transaction tree by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:16.399Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Expose a visible transaction by identifier'.
2021-01-04T17:36:16.401Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Do not expose an invisible transaction tree by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:16.615Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Do not expose an invisible flat transaction by identifier'.
2021-01-04T17:36:16.617Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return INVALID when looking up an invalid transaction tree by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:17.424Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The same transaction trees should be served to all stakeholders'.
2021-01-04T17:36:17.426Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'Return NOT_FOUND when looking up an inexistent transaction tree by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:17.814Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Return INVALID when looking up an invalid transaction tree by event identifier'.
2021-01-04T17:36:17.816Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Return INVALID_ARGUMENT when looking up a transaction tree by event identifier without specifying a party' with a timeout of 5 minutes.
2021-01-04T17:36:17.820Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Return INVALID_ARGUMENT when looking up a transaction tree by event identifier without specifying a party'.
2021-01-04T17:36:17.821Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Expose a visible flat transaction by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:18.657Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Return NOT_FOUND when looking up an inexistent transaction tree by event identifier'.
2021-01-04T17:36:18.659Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Do not expose an invisible flat transaction by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:19.309Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose the same events for each transaction as the output of getTransactionTrees'.
2021-01-04T17:36:19.310Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Return INVALID when looking up a flat transaction by an invalid event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:19.567Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose a visible transaction tree by event identifier'.
2021-01-04T17:36:19.569Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Return NOT_FOUND when looking up an inexistent flat transaction by event identifier' with a timeout of 5 minutes.
2021-01-04T17:36:20.095Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Do not expose an invisible transaction tree by identifier'.
2021-01-04T17:36:20.096Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Return INVALID_ARGUMENT when looking up a flat transaction by event identifier without specifying a party' with a timeout of 5 minutes.
2021-01-04T17:36:20.102Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Return INVALID_ARGUMENT when looking up a flat transaction by event identifier without specifying a party'.
2021-01-04T17:36:20.104Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Archives should always come after creations when subscribing as a single party' with a timeout of 10 minutes.
2021-01-04T17:36:20.456Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Return INVALID when looking up a flat transaction by an invalid event identifier'.
2021-01-04T17:36:20.457Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Archives should always come after creations when subscribing as more than on party' with a timeout of 10 minutes.
2021-01-04T17:36:20.694Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Return NOT_FOUND when looking up an inexistent flat transaction by event identifier'.
2021-01-04T17:36:20.695Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'The event identifiers in the flat stream should be a subset of those in the trees stream' with a timeout of 10 minutes.
2021-01-04T17:36:21.315Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose a visible flat transaction by event identifier'.
2021-01-04T17:36:21.317Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The witnesses in the flat stream should be a subset of those in the trees stream' with a timeout of 10 minutes.
2021-01-04T17:36:22.134Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Do not expose an invisible flat transaction by event identifier'.
2021-01-04T17:36:22.135Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Started 'The ledger should respect disclosure rules' with a timeout of 5 minutes.
2021-01-04T17:36:34.425Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Expose the same events for each transaction as the output of getTransactions'.
2021-01-04T17:36:34.427Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Exercising on a wrong type fails' with a timeout of 5 minutes.
2021-01-04T17:36:46.381Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Archives should always come after creations when subscribing as a single party'.
2021-01-04T17:36:46.383Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Started 'Fetching of the wrong type fails' with a timeout of 5 minutes.
2021-01-04T17:36:59.067Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'Archives should always come after creations when subscribing as more than on party'.
2021-01-04T17:37:05.936Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The event identifiers in the flat stream should be a subset of those in the trees stream'.
2021-01-04T17:37:12.837Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Do not expose an invisible transaction tree by event identifier'.
2021-01-04T17:37:13.487Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Finished 'The witnesses in the flat stream should be a subset of those in the trees stream'.
2021-01-04T17:37:13.561Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Exercising on a wrong type fails'.
2021-01-04T17:37:13.675Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Test visibility via contract fetches for the paint-offer flow'.
2021-01-04T17:37:14.162Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'Fetching of the wrong type fails'.
2021-01-04T17:37:14.519Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[ka.actor.default-dispatcher-10] - Finished 'The ledger should respect disclosure rules'.
2021-01-04T17:37:14.521Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-4] - Running 1 tests, 1 at a time.
2021-01-04T17:37:14.523Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Started 'It should be able to get, set and restore the time model' with a timeout of 5 minutes.
2021-01-04T17:37:14.997Z INFO  c.d.l.a.t.i.LedgerTestCasesRunner@[kka.actor.default-dispatcher-8] - Finished 'It should be able to get, set and restore the time model'.
2021-01-04T17:37:14.998Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[kka.actor.default-dispatcher-4] - Disconnecting from participant at localhost:6865...
2021-01-04T17:37:15.012Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[kka.actor.default-dispatcher-4] - Connection to participant at localhost:6865 shut down.
2021-01-04T17:37:15.018Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[kka.actor.default-dispatcher-4] - Connection to participant at localhost:6865 closed.

################################################################################
#
# TEST REPORT
#
################################################################################

### RUN INFORMATION

identifierSuffix = 1080d243de33d

### SUCCESSES

DivulgenceIT
- [DivulgenceIT:DivulgenceTx] Divulged contracts should not be exposed by the transaction service ... Success (6894 ms)
- [DivulgenceIT:DivulgenceAcs] Divulged contracts should not be exposed by the active contract service ... Success (6400 ms)
- [DivulgenceIT:DivulgenceKeys] Divulgence should behave as expected in a workflow involving keys ... Success (10072 ms)

WitnessesIT
- [WitnessesIT:RespectDisclosureRules] The ledger should respect disclosure rules ... Success (52384 ms)

WronglyTypedContractIdIT
- [WronglyTypedContractIdIT:WTExerciseFails] Exercising on a wrong type fails ... Success (39134 ms)
- [WronglyTypedContractIdIT:WTFetchFails] Fetching of the wrong type fails ... Success (27779 ms)

ActiveContractsServiceIT
- [ActiveContractsServiceIT:ACSinvalidLedgerId] The ActiveContractService should fail for requests with an invalid ledger identifier ... Success (629 ms)
- [ActiveContractsServiceIT:ACSemptyResponse] The ActiveContractService should succeed with an empty response if no contracts have been created for a party ... Success (825 ms)
- [ActiveContractsServiceIT:ACSallContracts] The ActiveContractService should return all active contracts ... Success (5273 ms)
- [ActiveContractsServiceIT:ACSfilterContracts] The ActiveContractService should return contracts filtered by templateId ... Success (5632 ms)
- [ActiveContractsServiceIT:ACSarchivedContracts] The ActiveContractService does not return archived contracts ... Success (7202 ms)
- [ActiveContractsServiceIT:ACSusableOffset] The ActiveContractService should return a usable offset to resume streaming transactions ... Success (3868 ms)
- [ActiveContractsServiceIT:ACSverbosity] The ActiveContractService should emit field names only if the verbose flag is set to true ... Success (3220 ms)
- [ActiveContractsServiceIT:ACSmultiParty] The ActiveContractsService should return contracts for the requesting parties ... Success (10097 ms)
- [ActiveContractsServiceIT:ACSagreementText] The ActiveContractService should properly fill the agreementText field ... Success (4012 ms)
- [ActiveContractsServiceIT:ACSeventId] The ActiveContractService should properly fill the eventId field ... Success (2822 ms)
- [ActiveContractsServiceIT:ACSnoWitnessedContracts] The ActiveContractService should not return witnessed contracts ... Success (4432 ms)
- [ActiveContractsServiceIT:ACSnoDivulgedContracts] The ActiveContractService should not return divulged contracts ... Success (5580 ms)

LedgerConfigurationServiceIT
- [LedgerConfigurationServiceIT:ConfigSucceeds] Return a valid configuration for a valid request ... Success (35 ms)
- [LedgerConfigurationServiceIT:ConfigLedgerId] Return NOT_FOUND to invalid ledger identifier ... Success (5 ms)
- [LedgerConfigurationServiceIT:CSLSuccessIfMaxDedplicationTimeRight] Submission returns OK if deduplication time is within the accepted interval ... Success (1146 ms)
- [LedgerConfigurationServiceIT:CSLSuccessIfMaxDeduplicationTimeExceeded] Submission returns OK if deduplication time is too high ... Success (1261 ms)

PartyManagementServiceIT
- [PartyManagementServiceIT:PMNonEmptyParticipantID] Asking for the participant identifier should return a non-empty string ... Success (12 ms)
- [PartyManagementServiceIT:PMAllocateWithHint] It should be possible to provide a hint when allocating a party ... Success (1217 ms)
- [PartyManagementServiceIT:PMAllocateWithoutHint] It should be possible to not provide a hint when allocating a party ... Success (1921 ms)
- [PartyManagementServiceIT:PMAllocateWithoutDisplayName] It should be possible to not provide a display name when allocating a party ... Success (1436 ms)
- [PartyManagementServiceIT:PMAllocateDuplicateDisplayName] It should be possible to allocate parties with the same display names ... Success (21577 ms)
- [PartyManagementServiceIT:PMAllocateOneHundred] It should create unique party names when allocating many parties ... Success (19383 ms)
- [PartyManagementServiceIT:PMGetParties] It should get details for multiple parties, if they exist ... Success (21068 ms)
- [PartyManagementServiceIT:PMListKnownParties] It should list all known, previously-allocated parties ... Success (23106 ms)
- [PartyManagementServiceIT:PMGetPartiesIsLocal] GetParties should correctly report whether parties are local or not ... Success (23326 ms)

PackageServiceIT
- [PackageServiceIT:PackagesList] Listing packages should return a result ... Success (17 ms)
- [PackageServiceIT:PackagesGet] Getting package content should return a valid result ... Success (24 ms)
- [PackageServiceIT:PackagesGetUnknown] Getting package content for an unknown package should fail ... Success (6 ms)
- [PackageServiceIT:PackagesStatus] Getting package status should return a valid result ... Success (24 ms)
- [PackageServiceIT:PackagesStatusUnknown] Getting package status for an unknown package should fail ... Success (7 ms)

ContractKeysIT
- [ContractKeysIT:CKFetchOrLookup] Divulged contracts cannot be fetched or looked up by key by non-stakeholders ... Success (8475 ms)
- [ContractKeysIT:CKNoFetchUndisclosed] Contract Keys should reject fetching an undisclosed contract ... Success (9374 ms)
- [ContractKeysIT:CKMaintainerScoped] Contract keys should be scoped by maintainer ... Success (42384 ms)
- [ContractKeysIT:CKRecreate] Contract keys can be recreated in single transaction ... Success (3352 ms)
- [ContractKeysIT:CKTransients] Contract keys created by transient contracts are properly archived ... Success (6092 ms)
- [ContractKeysIT:CKExposedByTemplate] The contract key should be exposed if the template specifies one ... Success (2069 ms)
- [ContractKeysIT:CKExerciseByKey] Exercising by key should be possible only when the corresponding contract is available ... Success (3831 ms)

ClosedWorldIT
- [ClosedWorldIT:ClosedWorldObserver] Cannot execute a transaction that references unallocated observer parties ... Success (3049 ms)

CommandServiceIT
- [CommandServiceIT:CSsubmitAndWaitBasic] SubmitAndWait creates a contract of the expected template ... Success (2992 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionIdBasic] SubmitAndWaitForTransactionId returns a valid transaction identifier ... Success (2877 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionBasic] SubmitAndWaitForTransaction returns a transaction ... Success (2733 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionTreeBasic] SubmitAndWaitForTransactionTree returns a transaction tree ... Success (2645 ms)
- [CommandServiceIT:CSduplicateSubmitAndWaitBasic] SubmitAndWait should fail on duplicate requests ... Success (2732 ms)
- [CommandServiceIT:CSduplicateSubmitAndWaitForTransactionId] SubmitAndWaitForTransactionId should fail on duplicate requests ... Success (2619 ms)
- [CommandServiceIT:CSduplicateSubmitAndWaitForTransaction] SubmitAndWaitForTransaction should fail on duplicate requests ... Success (2636 ms)
- [CommandServiceIT:CSduplicateSubmitAndWaitForTransactionTree] SubmitAndWaitForTransactionTree should fail on duplicate requests ... Success (2497 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionIdInvalidLedgerId] SubmitAndWaitForTransactionId should fail for invalid ledger ids ... Success (1447 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionInvalidLedgerId] SubmitAndWaitForTransaction should fail for invalid ledger ids ... Success (1300 ms)
- [CommandServiceIT:CSsubmitAndWaitForTransactionTreeInvalidLedgerId] SubmitAndWaitForTransactionTree should fail for invalid ledger ids ... Success (1187 ms)
- [CommandServiceIT:CSRefuseBadParameter] The submission of a creation that contains a bad parameter label should result in an INVALID_ARGUMENT ... Success (1216 ms)
- [CommandServiceIT:CSReturnStackTrace] A submission resulting in an interpretation error should return the stack trace ... Success (3413 ms)
- [CommandServiceIT:CSDiscloseCreateToObservers] Disclose create to observers ... Success (8805 ms)
- [CommandServiceIT:CSDiscloseExerciseToObservers] Disclose exercise to observers ... Success (9856 ms)
- [CommandServiceIT:CSHugeCommandSubmission] The server should accept a submission with 15 commands ... Success (3481 ms)
- [CommandServiceIT:CSCallablePayout] Run CallablePayout and return the right events ... Success (9738 ms)
- [CommandServiceIT:CSReadyForExercise] It should be possible to exercise a choice on a created contract ... Success (4794 ms)
- [CommandServiceIT:CSBadNumericValues] Reject unrepresentable numeric values ... Success (2194 ms)
- [CommandServiceIT:CSCreateAndExercise] Implement create-and-exercise correctly ... Success (3606 ms)
- [CommandServiceIT:CSBadCreateAndExercise] Fail create-and-exercise on bad create arguments ... Success (1412 ms)
- [CommandServiceIT:CSCreateAndBadExerciseArguments] Fail create-and-exercise on bad choice arguments ... Success (1267 ms)
- [CommandServiceIT:CSCreateAndBadExerciseChoice] Fail create-and-exercise on invalid choice ... Success (1205 ms)

HealthServiceIT
- [HealthServiceIT:HScheck] The Health.Check endpoint reports everything is well ... Success (19 ms)
- [HealthServiceIT:HSwatch] The Health.Watch endpoint reports everything is well ... Success (1009 ms)

CommandDeduplicationIT
- [CommandDeduplicationIT:CDSimpleDeduplicationBasic] Deduplicate commands within the deduplication time window ... Success (8266 ms)
- [CommandDeduplicationIT:CDStopOnSubmissionFailure] Stop deduplicating commands on submission failure ... Success (1208 ms)
- [CommandDeduplicationIT:CDStopOnCompletionFailure] Stop deduplicating commands on completion failure ... Success (5766 ms)
- [CommandDeduplicationIT:CDSimpleDeduplicationCommandClient] Deduplicate commands within the deduplication time window using the command client ... Success (8497 ms)
- [CommandDeduplicationIT:CDDeduplicateSubmitterBasic] Commands with identical submitter and command identifier should be deduplicated by the submission client ... Success (2523 ms)
- [CommandDeduplicationIT:CDDeduplicateSubmitterCommandClient] Commands with identical submitter and command identifier should be deduplicated by the command client ... Success (3710 ms)

CommandSubmissionCompletionIT
- [CommandSubmissionCompletionIT:CSCCompletions] Read completions correctly with a correct application identifier and reading party ... Success (2513 ms)
- [CommandSubmissionCompletionIT:CSCNoCompletionsWithoutRightAppId] Read no completions without the correct application identifier ... Success (6191 ms)
- [CommandSubmissionCompletionIT:CSCAfterEnd] An OUT_OF_RANGE error should be returned when subscribing to completions past the ledger end ... Success (1293 ms)
- [CommandSubmissionCompletionIT:CSCNoCompletionsWithoutRightParty] Read no completions without the correct party ... Success (6312 ms)
- [CommandSubmissionCompletionIT:CSCRefuseBadChoice] The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT ... Success (2645 ms)
- [CommandSubmissionCompletionIT:CSCSubmitWithInvalidLedgerId] Submit should fail for an invalid ledger identifier ... Success (1427 ms)
- [CommandSubmissionCompletionIT:CSCDisallowEmptyTransactionsSubmission] The submission of an empty command should be rejected with INVALID_ARGUMENT ... Success (1424 ms)
- [CommandSubmissionCompletionIT:CSCHandleMultiPartySubscriptions] Listening for completions should support multi-party subscriptions ... Success (2269 ms)

ConfigManagementServiceIT
- [ConfigManagementServiceIT:CMSetAndGetTimeModel] It should be able to get, set and restore the time model ... Success (474 ms)

SemanticTests
- [SemanticTests:SemanticDoubleSpendBasic] Cannot double spend across transactions ... Success (19070 ms)
- [SemanticTests:SemanticConcurrentDoubleSpend] Cannot concurrently double spend across transactions ... Success (31654 ms)
- [SemanticTests:SemanticDoubleSpendSameTx] Cannot double spend within a transaction ... Success (3250 ms)
- [SemanticTests:SemanticDoubleSpendShared] Different parties cannot spend the same contract ... Success (12233 ms)
- [SemanticTests:SemanticPaintOffer] Conduct the paint offer workflow successfully ... Success (7607 ms)
- [SemanticTests:SemanticPaintCounterOffer] Conduct the paint counter-offer workflow successfully ... Success (9282 ms)
- [SemanticTests:SemanticPartialSignatories] A signatory should not be able to create a contract on behalf of two parties ... Success (1715 ms)
- [SemanticTests:SemanticAcceptOnBehalf] It should not be possible to exercise a choice without the consent of the controller ... Success (5641 ms)
- [SemanticTests:SemanticPrivacyProjections] Test visibility via contract fetches for the paint-offer flow ... Success (108488 ms)
- [SemanticTests:SemanticDivulgence] Respect divulgence rules ... Success (28144 ms)

PackageManagementServiceIT
- [PackageManagementServiceIT:PackageManagementEmptyUpload] An attempt at uploading an empty payload should fail ... Success (10 ms)
- [PackageManagementServiceIT:PackageManagementLoad] Concurrent uploads of the same package should be idempotent and result in the package being available for use ... Success (25181 ms)

TransactionServiceIT
- [TransactionServiceIT:TXBeginToBegin] An empty stream should be served when getting transactions from and to the beginning of the ledger ... Success (1145 ms)
- [TransactionServiceIT:TXTreesBeginToBegin] An empty stream of trees should be served when getting transactions from and to the beginning of the ledger ... Success (1196 ms)
- [TransactionServiceIT:TXEndToEnd] An empty stream should be served when getting transactions from and to the end of the ledger ... Success (3224 ms)
- [TransactionServiceIT:TXAfterEnd] An OUT_OF_RANGE error should be returned when subscribing past the ledger end ... Success (3267 ms)
- [TransactionServiceIT:TXTreesAfterEnd] An OUT_OF_RANGE error should be returned when subscribing to trees past the ledger end ... Success (3356 ms)
- [TransactionServiceIT:TXServeUntilCancellation] Items should be served until the client cancels ... Success (4643 ms)
- [TransactionServiceIT:TXServeTreesUntilCancellation] Trees should be served until the client cancels ... Success (7323 ms)
- [TransactionServiceIT:TXTreeBlinding] Trees should be served according to the blinding/projection rules ... Success (23631 ms)
- [TransactionServiceIT:TXRejectEmptyFilter] A query with an empty transaction filter should be rejected with an INVALID_ARGUMENT status ... Success (3817 ms)
- [TransactionServiceIT:TXCompleteOnLedgerEnd] A stream should complete as soon as the ledger end is hit ... Success (9463 ms)
- [TransactionServiceIT:TXCompleteTreesOnLedgerEnd] A stream of trees should complete as soon as the ledger end is hit ... Success (8738 ms)
- [TransactionServiceIT:TXProcessInTwoChunks] Serve the complete sequence of transactions even if processing is stopped and resumed ... Success (11505 ms)
- [TransactionServiceIT:TXParallel] The same data should be served for more than 1 identical, parallel requests ... Success (7545 ms)
- [TransactionServiceIT:TXNotDivulge] Data should not be exposed to parties unrelated to a transaction ... Success (5764 ms)
- [TransactionServiceIT:TXRejectBeginAfterEnd] A request with the end before the begin should be rejected with INVALID_ARGUMENT ... Success (5278 ms)
- [TransactionServiceIT:TXHideCommandIdToNonSubmittingStakeholders] A transaction should be visible to a non-submitting stakeholder but its command identifier should be empty ... Success (3826 ms)
- [TransactionServiceIT:TXFilterByTemplate] The transaction service should correctly filter by template identifier ... Success (3108 ms)
- [TransactionServiceIT:TXUseCreateToExercise] Should be able to directly use a contract identifier to exercise a choice ... Success (4194 ms)
- [TransactionServiceIT:TXContractIdFromExerciseWhenFilter] Expose contract identifiers that are results of exercising choices when filtering by template ... Success (3019 ms)
- [TransactionServiceIT:TXRejectOnFailingAssertion] Reject a transaction on a failing assertion ... Success (2042 ms)
- [TransactionServiceIT:TXCreateWithAnyType] Creates should not have issues dealing with any type of argument ... Success (1987 ms)
- [TransactionServiceIT:TXExerciseWithAnyType] Exercise should not have issues dealing with any type of argument ... Success (4120 ms)
- [TransactionServiceIT:TXVeryLongList] Accept a submission with a very long list (10,000 items) ... Success (3694 ms)
- [TransactionServiceIT:TXNotArchiveNonConsuming] Expressing a non-consuming choice on a contract should not result in its archival ... Success (10561 ms)
- [TransactionServiceIT:TXRequireAuthorization] Require only authorization of chosen branching signatory ... Success (3111 ms)
- [TransactionServiceIT:TXNotDiscloseCreateToNonSignatory] Not disclose create to non-chosen branching signatory ... Success (9521 ms)
- [TransactionServiceIT:TXDiscloseCreateToSignatory] Disclose create to the chosen branching controller ... Success (3291 ms)
- [TransactionServiceIT:TXNotDiscloseCreateToNonChosenBranchingController] Not disclose create to non-chosen branching controller ... Success (9302 ms)
- [TransactionServiceIT:TXDiscloseCreateToObservers] Disclose create to observers ... Success (2760 ms)
- [TransactionServiceIT:TXUnitAsArgumentToNothing] DAML engine returns Unit as argument to Nothing ... Success (2923 ms)
- [TransactionServiceIT:TXAgreementTextExplicit] Expose the agreement text for templates with an explicit agreement text ... Success (2923 ms)
- [TransactionServiceIT:TXAgreementTextDefault] Expose the default text for templates without an agreement text ... Success (3100 ms)
- [TransactionServiceIT:TXStakeholders] Expose the correct stakeholders ... Success (3356 ms)
- [TransactionServiceIT:TXNoContractKey] There should be no contract key if the template does not specify one ... Success (3326 ms)
- [TransactionServiceIT:TXMultiActorChoiceOkBasic] Accept exercising a well-authorized multi-actor choice ... Success (7802 ms)
- [TransactionServiceIT:TXMultiActorChoiceOkCoincidingControllers] Accept exercising a well-authorized multi-actor choice with coinciding controllers ... Success (7808 ms)
- [TransactionServiceIT:TXRejectMultiActorMissingAuth] Reject exercising a multi-actor choice with missing authorizers ... Success (3407 ms)
- [TransactionServiceIT:TXRejectMultiActorExcessiveAuth] Reject exercising a multi-actor choice with too many authorizers ... Success (5630 ms)
- [TransactionServiceIT:TXNoReorder] Don't reorder fields in data structures of choices ... Success (4424 ms)
- [TransactionServiceIT:TXSingleMultiSameBasic] The same transaction should be served regardless of subscribing as one or multiple parties ... Success (4373 ms)
- [TransactionServiceIT:TXSingleMultiSameTrees] The same transaction trees should be served regardless of subscribing as one or multiple parties ... Success (3915 ms)
- [TransactionServiceIT:TXSingleMultiSameStakeholders] The same transaction should be served to all stakeholders ... Success (8516 ms)
- [TransactionServiceIT:TXSingleMultiSameTreesStakeholders] The same transaction trees should be served to all stakeholders ... Success (8477 ms)
- [TransactionServiceIT:TXFetchContractCreatedInTransaction] It should be possible to fetch a contract created within a transaction ... Success (3574 ms)
- [TransactionServiceIT:TXFlatTransactionsWrongLedgerId] The getTransactions endpoint should reject calls with the wrong ledger identifier ... Success (1129 ms)
- [TransactionServiceIT:TXTransactionTreesWrongLedgerId] The getTransactionTrees endpoint should reject calls with the wrong ledger identifier ... Success (1059 ms)
- [TransactionServiceIT:TXTransactionTreeByIdWrongLedgerId] The getTransactionTreeById endpoint should reject calls with the wrong ledger identifier ... Success (1197 ms)
- [TransactionServiceIT:TXFlatTransactionByIdWrongLedgerId] The getFlatTransactionById endpoint should reject calls with the wrong ledger identifier ... Success (1195 ms)
- [TransactionServiceIT:TXTransactionTreeByEventIdWrongLedgerId] The getTransactionTreeByEventId endpoint should reject calls with the wrong ledger identifier ... Success (1196 ms)
- [TransactionServiceIT:TXFlatTransactionByEventIdWrongLedgerId] The getFlatTransactionByEventId endpoint should reject calls with the wrong ledger identifier ... Success (992 ms)
- [TransactionServiceIT:TXTransactionTreeByIdWrongLedgerId] The ledgerEnd endpoint should reject calls with the wrong ledger identifier ... Success (5 ms)
- [TransactionServiceIT:TXTransactionTreeByIdBasic] Expose a visible transaction tree by identifier ... Success (3884 ms)
- [TransactionServiceIT:TXInvisibleTransactionTreeById] Do not expose an invisible transaction tree by identifier ... Success (8506 ms)
- [TransactionServiceIT:TXTransactionTreeByIdNotFound] Return NOT_FOUND when looking up an inexistent transaction tree by identifier ... Success (1319 ms)
- [TransactionServiceIT:TXTransactionTreeByIdNotFound] Return INVALID_ARGUMENT when looking up a transaction tree by identifier without specifying a party ... Success (4 ms)
- [TransactionServiceIT:TXTransactionTreeByIdSameAsTransactionStream] Expose the same events for each transaction as the output of getTransactionTrees ... Success (7474 ms)
- [TransactionServiceIT:TXFlatTransactionByIdBasic] Expose a visible transaction by identifier ... Success (3737 ms)
- [TransactionServiceIT:TXInvisibleFlatTransactionById] Do not expose an invisible flat transaction by identifier ... Success (3587 ms)
- [TransactionServiceIT:TXFlatTransactionByIdNotFound] Return NOT_FOUND when looking up an inexistent flat transaction by identifier ... Success (1024 ms)
- [TransactionServiceIT:TXFlatTransactionByIdNotFound] Return INVALID_ARGUMENT when looking up a flat transaction by identifier without specifying a party ... Success (4 ms)
- [TransactionServiceIT:TXFlatTransactionByIdSameAsTransactionStream] Expose the same events for each transaction as the output of getTransactions ... Success (18575 ms)
- [TransactionServiceIT:TXTransactionTreeByEventIdBasic] Expose a visible transaction tree by event identifier ... Success (3659 ms)
- [TransactionServiceIT:TXInvisibleTransactionTreeByEventId] Do not expose an invisible transaction tree by event identifier ... Success (56436 ms)
- [TransactionServiceIT:TXTransactionTreeByEventIdInvalid] Return INVALID when looking up an invalid transaction tree by event identifier ... Success (1198 ms)
- [TransactionServiceIT:TXTransactionTreeByEventIdNotFound] Return NOT_FOUND when looking up an inexistent transaction tree by event identifier ... Success (1231 ms)
- [TransactionServiceIT:TXTransactionTreeByEventIdNotFound] Return INVALID_ARGUMENT when looking up a transaction tree by event identifier without specifying a party ... Success (4 ms)
- [TransactionServiceIT:TXFlatTransactionByEventIdBasic] Expose a visible flat transaction by event identifier ... Success (3494 ms)
- [TransactionServiceIT:TXInvisibleFlatTransactionByEventId] Do not expose an invisible flat transaction by event identifier ... Success (3475 ms)
- [TransactionServiceIT:TXFlatTransactionByEventIdInvalid] Return INVALID when looking up a flat transaction by an invalid event identifier ... Success (1145 ms)
- [TransactionServiceIT:TXFlatTransactionByEventIdNotFound] Return NOT_FOUND when looking up an inexistent flat transaction by event identifier ... Success (1125 ms)
- [TransactionServiceIT:TXFlatTransactionByEventIdNotFound] Return INVALID_ARGUMENT when looking up a flat transaction by event identifier without specifying a party ... Success (5 ms)
- [TransactionServiceIT:TXSingleSubscriptionInOrder] Archives should always come after creations when subscribing as a single party ... Success (26277 ms)
- [TransactionServiceIT:TXMultiSubscriptionInOrder] Archives should always come after creations when subscribing as more than on party ... Success (38609 ms)
- [TransactionServiceIT:TXFlatSubsetOfTrees] The event identifiers in the flat stream should be a subset of those in the trees stream ... Success (45241 ms)
- [TransactionServiceIT:TXFlatWitnessesSubsetOfTrees] The witnesses in the flat stream should be a subset of those in the trees stream ... Success (52170 ms)

IdentityIT
- [IdentityIT:IdNotEmpty] A ledger should return a non-empty string as its identity ... Success (5 ms)
```