### PR TITLE
update sbt-dependency-graph version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,15 @@ jobs:
       - blackduck-scan
 
 workflows:
-  version: 2
   workflow:
     jobs:
-      - build
+      - build:
+          context: blackduck
+      - blackduck-build:
+          context: blackduck
+          filters:
+            branches:
+              only: /^blackduck.*/
 
   blackduck:
     triggers:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11")


### PR DESCRIPTION
Resolves failing Blackduck scan as a newer sbt-dependency-graph version needs to be used with sbt 1.3.x in order for the dependency results to be returned in a consumable form for blackduck